### PR TITLE
 Fix checkpoint serialization crash by including val_dataset to the datamodule hyperparameters being ignored

### DIFF
--- a/src/data/audioset_datamodule.py
+++ b/src/data/audioset_datamodule.py
@@ -56,7 +56,8 @@ class AudioSetDataModule(L.LightningDataModule):
         """
         
         super().__init__()
-        self.save_hyperparameters(logger=False, ignore=["mask_collator", "train_dataset", "eval_dataset"])
+        self.save_hyperparameters(logger=False,
+                                  ignore=["mask_collator", "train_dataset", "val_dataset","eval_dataset"])
         
         # Data paths
         self.train_dataset = train_dataset


### PR DESCRIPTION
This fixes a training crash during checkpoint saving:

TypeError: h5py objects cannot be pickled

Root cause -

AudioSetDataModule.__init__ calls self.save_hyperparameters(...) and ignores train_dataset / eval_dataset, but not val_dataset. When Lightning checkpoints the model, it serializes datamodule hyperparameters. val_dataset can carry non-picklable h5py internals, which causes torch.save to fail.

Fix -
Exclude val_dataset from save_hyperparameters(..., ignore=[...]).